### PR TITLE
fix: redirect errors

### DIFF
--- a/src/app/(site)/apply/_components/application-form.tsx
+++ b/src/app/(site)/apply/_components/application-form.tsx
@@ -7,7 +7,7 @@ import * as yup from "yup";
 import axios from "axios";
 import Loading from "@/components/loading";
 import SchoolSuggestion from "./school-suggestion";
-import { redirect } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { applicationSchema } from "@/schemas/application";
 
 interface ApplicationState {
@@ -114,6 +114,7 @@ interface ApplicationProps {
 
 const ApplicationForm: React.FC<ApplicationProps> = (props) => {
   const { url } = props;
+  const router = useRouter();
   const {
     register,
     handleSubmit,
@@ -171,10 +172,10 @@ const ApplicationForm: React.FC<ApplicationProps> = (props) => {
       };
       await axios.post("/api/application", newApplication);
       setLoading(false);
-      redirect("/portal");
+      router.push("/portal");
     } catch (error) {
       setLoading(false);
-      redirect("/error");
+      router.push("/error");
     }
   };
 


### PR DESCRIPTION
After successfullying submitting an application form, the site would throw a `NEXT_REDIRECT` error since the current redirection is done server side in a client component. To fix this, I switched from server-side redirection to client side redirection using the router. [We can use `redirect`  on the client side](https://nextjs.org/docs/14/app/api-reference/functions/redirect#client-component), but the router approach seems simpler. 