### PR TITLE
Increase width of response column for each applicant 

### DIFF
--- a/src/app/(site)/admin/_components/application.tsx
+++ b/src/app/(site)/admin/_components/application.tsx
@@ -54,7 +54,8 @@ export const Application: React.FC<ApplicationProps> = (props) => {
       <td className="whitespace-normal text-sm font-medium leading-5">
         {application.skillLevel}
       </td>
-      <td className="whitespace-normal text-sm font-medium leading-5">
+      {/* Manually increase width of the response column */}
+      <td className="whitespace-normal text-sm font-medium leading-5 min-w-[250px] md:min-w-[300px]">
         {application.response}
       </td>
       {/* Button logic, if application has already been approved/rejected, it'll display that */}

--- a/src/app/(site)/admin/_components/application.tsx
+++ b/src/app/(site)/admin/_components/application.tsx
@@ -55,7 +55,7 @@ export const Application: React.FC<ApplicationProps> = (props) => {
         {application.skillLevel}
       </td>
       {/* Manually increase width of the response column */}
-      <td className="whitespace-normal text-sm font-medium leading-5 min-w-[250px] md:min-w-[300px]">
+      <td className="min-w-[250px] whitespace-normal text-sm font-medium leading-5 md:min-w-[300px]">
         {application.response}
       </td>
       {/* Button logic, if application has already been approved/rejected, it'll display that */}


### PR DESCRIPTION
The width of the response column (in applications section of admin page) seems too small, which decreases readability. I increased the width to make this more readable.

![image](https://github.com/user-attachments/assets/267a4bae-3379-405f-b83d-3633b1ebb3c4)
