### PR TITLE
use different env var for checks

### DIFF
--- a/src/app/(site)/apply/_components/apply-auth.tsx
+++ b/src/app/(site)/apply/_components/apply-auth.tsx
@@ -24,7 +24,7 @@ const ApplyAuth: React.FC<ApplyAuthProps> = ({ children }) => {
     new Date(now) >= new Date(openDate) &&
     new Date(now) <= new Date(applicationCloseDate);
 
-  if (applicationOpen || process.env.NODE_ENV !== "production") {
+  if (applicationOpen || process.env.NEXT_PUBLIC_TEST_APPS?.toLowerCase() === "true") {
     return <>{children}</>;
   }
 

--- a/src/app/(site)/apply/_components/apply-auth.tsx
+++ b/src/app/(site)/apply/_components/apply-auth.tsx
@@ -24,7 +24,10 @@ const ApplyAuth: React.FC<ApplyAuthProps> = ({ children }) => {
     new Date(now) >= new Date(openDate) &&
     new Date(now) <= new Date(applicationCloseDate);
 
-  if (applicationOpen || process.env.NEXT_PUBLIC_TEST_APPS?.toLowerCase() === "true") {
+  if (
+    applicationOpen ||
+    process.env.NEXT_PUBLIC_TEST_APPS?.toLowerCase() === "true"
+  ) {
     return <>{children}</>;
   }
 


### PR DESCRIPTION
use `NEXT_PUBLIC_TEST_APPS` instead of `NODE_ENV` since [`NODE_ENV` is always set to `production` during builds](https://github.com/vercel/next.js/discussions/48914)