### PR TITLE
fix: remove statement regarding application dates

### DIFF
--- a/src/lib/data/faq.ts
+++ b/src/lib/data/faq.ts
@@ -11,7 +11,7 @@ export const faqs: FAQType[] = [
     id: "faq2",
     question: "When is FullyHacks?",
     answer:
-      "FullyHacks will take place from April 12th to April 13th. The hackathon will be 100% in-person. Application dates will be revealed very soon :)"
+      "FullyHacks will take place from April 12th to April 13th. The hackathon will be 100% in-person."
   },
   {
     id: "faq3",


### PR DESCRIPTION
AFAICT application dates have already been revealed. 

Applications are due ...by 11:59 PM (PDT) on March 24, 2025.

Let's try to avoid misleading readers of the FAQ into believing the applications are not open.

Thankfully, it is **NOT** very likely that users have been misled:

1) The apply button is active and works

2) Other FAQ question(s) mentions due dates for applications